### PR TITLE
Add support for setting the ingressClassName

### DIFF
--- a/assemblyline/templates/ingress.yaml
+++ b/assemblyline/templates/ingress.yaml
@@ -24,6 +24,9 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+{{ if .Values.ingressClassName }}
+  ingressClassName: {{.Values.ingressClassName }}
+{{end}}
   tls:
     - hosts: [{{ .Values.configuration.ui.fqdn }}]
       secretName: {{ if .Values.tlsSecretName }} {{.Values.tlsSecretName }} {{else}} {{ .Release.Name }}-generated-cert {{end}}


### PR DESCRIPTION
See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation