### PR TITLE
Fix jobs.yaml value

### DIFF
--- a/assemblyline/templates/jobs.yaml
+++ b/assemblyline/templates/jobs.yaml
@@ -93,7 +93,7 @@ spec:
             value: 'True'
         resources:
           requests:
-            cpu: {{ .Values.installJobReqCPU }}
+            cpu: {{ $.Values.installJobReqCPU }}
           limits:
             cpu: 1
             {{ if $.Values.namespaceResourceLimited }}


### PR DESCRIPTION
Error parsing:
$ sudo microk8s helm install assemblyline ~/git/assemblyline-helm-chart/assemblyline -f ~/git/deployment/values.yaml -n al

Error: INSTALLATION FAILED: template: assemblyline/templates/jobs.yaml:96:27: executing "assemblyline/templates/jobs.yaml" at <.Values.installJobReqCPU>: can't evaluate field Values in type interface {}