### PR TITLE
pass in official ES solution for Elasticsearch

### DIFF
--- a/appliance/values.yaml
+++ b/appliance/values.yaml
@@ -131,7 +131,7 @@ configuration:
 #         to your system as the default value is quite small.
 datastore:
   replicas: 1
-  esJavaOpts: "-Xms2g -Xmx2g"
+  esJavaOpts: "-Xms2g -Xmx2g -Dlog4j2.formatMsgNoLookups=true"
   resources:
     requests:
       cpu: 250m

--- a/assemblyline/values.yaml
+++ b/assemblyline/values.yaml
@@ -352,7 +352,7 @@ datastore:
     section: core
     component: datastore
   protocol: http
-  esJavaOpts: "-Xms4g -Xmx4g"
+  esJavaOpts: "-Xms4g -Xmx4g -Dlog4j2.formatMsgNoLookups=true"
   esConfig:
     elasticsearch.yml: |
       logger.level: WARN
@@ -787,7 +787,7 @@ log-storage:
   labels:
     section: core
     component: log-storage
-  esJavaOpts: "-Xms4g -Xmx4g"
+  esJavaOpts: "-Xms4g -Xmx4g -Dlog4j2.formatMsgNoLookups=true"
   protocol: http
   esConfig:
     elasticsearch.yml: |


### PR DESCRIPTION
We should consider upgrading our images to use 7.16.1 when it's released to cover items not fixed by this PR (ie. Logstash).