### PR TITLE
Updated release version of values.yaml to 4.2.stable from 4.1.stable

### DIFF
--- a/assemblyline/values.yaml
+++ b/assemblyline/values.yaml
@@ -1,5 +1,5 @@
 # Tags for the containers used
-release: "4.1.stable"
+release: "4.2.stable"
 
 # Images for containers used
 assemblylineCoreImage: cccs/assemblyline-core


### PR DESCRIPTION
Current version of 4.1.stable is causing issues within scaler & updater pods. Update pod is unable to find version 4.2.X and results to a STABLE channel of NONE. 