### PR TITLE
Set `log-storage.clusterHealthCheckParams` for default replica setting

### DIFF
--- a/assemblyline/values.yaml
+++ b/assemblyline/values.yaml
@@ -977,6 +977,8 @@ kibana:
 log-storage:
   clusterName: "log-storage"
   replicas: 1
+  # 'clusterHealthCheckParams' setting can be omitted if 'replicas' > 1
+  clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
   extraEnvs:
     - name: ELASTIC_USERNAME
       value: elastic


### PR DESCRIPTION
Related to: https://github.com/CybercentreCanada/assemblyline/issues/69

To avoid interfering with the replica count of other deployments, let's set the appropriate cluster health check.