### PR TITLE
fix indentation of external lookup node affinity

### DIFF
--- a/assemblyline/templates/ui-plugin-lookups.yaml
+++ b/assemblyline/templates/ui-plugin-lookups.yaml
@@ -64,7 +64,7 @@ spec:
       {{- if $.Values.nodeAffinity }}
       affinity:
         nodeAffinity:
-          {{ $.Values.nodeAffinity | toYaml | indent 10 }}
+{{ $.Values.nodeAffinity | toYaml | indent 10 }}
       {{- end }}
       {{- if $lookupConfig.securityContext }}
       securityContext:


### PR DESCRIPTION
Indentation of first line was incorrect causing errors when nodeAffinity was set.