### PR TITLE
Update service account roles to `list`, `patch` NetworkPolicy

### DIFF
--- a/assemblyline/templates/service-accounts.yaml
+++ b/assemblyline/templates/service-accounts.yaml
@@ -65,7 +65,7 @@ rules:
   verbs: ["watch"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "create", "patch", "update"]
+  verbs: ["get", "create", "patch", "update", "delete"]
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["create", "get", "patch"]


### PR DESCRIPTION
Related to: https://github.com/CybercentreCanada/assemblyline/issues/150

Includes bugfix to add ability to delete secrets to service account which Scaler attempts to do in-code.