### PR TITLE
feat: configurable ui-plugin-lookup egress (master)

### DIFF
--- a/assemblyline/templates/ui-plugin-lookups.yaml
+++ b/assemblyline/templates/ui-plugin-lookups.yaml
@@ -227,8 +227,10 @@ spec:
   policyTypes:
   - Egress
   egress:
-  - ports:
-    - port: 80
-    - port: 443
+  {{- if .Values.uiPlugins.lookup.egress }}
+    {{- .Values.uiPlugins.lookup.egress | toYaml | nindent 2 }}
+  {{- else -}}
+    {{- list | toYaml | indent 1 }}
+  {{- end }}
 ---
 {{- end }}

--- a/assemblyline/values.yaml
+++ b/assemblyline/values.yaml
@@ -1142,6 +1142,10 @@ filestore:
 uiPlugins:
   lookup:
     enabled: false
+    egress:
+    - ports:
+      - port: 80
+      - port: 443
     plugins:
       malwarebazaar:
         enabled: false


### PR DESCRIPTION
Allow ui lookup plugin egress to be specified via values.yaml.

Egress may not always be through HTTP or ports 80/443