### PR TITLE
Enable HSTS in Frontend pod and Support for AL_HSTS_MAX_AGE environment variable 

### DIFF
--- a/assemblyline/templates/configmaps.yaml
+++ b/assemblyline/templates/configmaps.yaml
@@ -37,6 +37,28 @@ data:
 
 
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config
+data:
+  serve.json: |
+    {
+      "headers": [
+        {
+          "source":"**/*",
+          "headers": [
+            {{ if .Values.enableHSTSHeader }}
+              {
+                "key": "Strict-Transport-Security", 
+                "value": "max-age={{ .Values.HSTSMaxAge }};includeSubDomains"
+              }
+            {{ end }}
+          ]
+        }
+      ]
+    }
+---
 # The assemblyline config that will be projected into all the assemblyline pods
 apiVersion: v1
 kind: ConfigMap

--- a/assemblyline/templates/configmaps.yaml
+++ b/assemblyline/templates/configmaps.yaml
@@ -37,6 +37,7 @@ data:
 
 
 ---
+{{ if .Values.enableHSTSHeader }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -48,17 +49,16 @@ data:
         {
           "source":"**/*",
           "headers": [
-            {{ if .Values.enableHSTSHeader }}
               {
                 "key": "Strict-Transport-Security", 
                 "value": "max-age={{ .Values.HSTSMaxAge }};includeSubDomains"
               }
-            {{ end }}
           ]
         }
       ]
     }
 ---
+{{ end }}
 # The assemblyline config that will be projected into all the assemblyline pods
 apiVersion: v1
 kind: ConfigMap

--- a/assemblyline/templates/ui.yaml
+++ b/assemblyline/templates/ui.yaml
@@ -64,6 +64,10 @@ spec:
                 secretKeyRef:
                   name: flask-secret
                   key: password
+          {{ if .Values.enableHSTSHeader }}
+            - name: AL_HSTS_MAX_AGE
+              value: "{{ .Values.HSTSMaxAge }}"
+          {{ end }}
           {{ if .Values.enableInternalEncryption }}
             - name: CERTFILE
               value: /etc/assemblyline/ssl/ui/tls.crt
@@ -410,12 +414,19 @@ spec:
             - name: frontend-cert
               mountPath: '/etc/certs/'
           {{ end }}
+            - name: config-map
+              mountPath: '/usr/src/app/serve.json'
+              subPath: serve.json
       volumes:
       {{ if .Values.enableInternalEncryption }}
         - name: frontend-cert
           secret:
             secretName: frontend-cert
       {{ end }}
+        - name: config-map
+          configMap:
+            name: frontend-config
+ 
 {{ if .Values.separateIngestAPI }}
 ---
 apiVersion: v1

--- a/assemblyline/templates/ui.yaml
+++ b/assemblyline/templates/ui.yaml
@@ -414,18 +414,22 @@ spec:
             - name: frontend-cert
               mountPath: '/etc/certs/'
           {{ end }}
+          {{ if .Values.enableHSTSHeader }}
             - name: config-map
               mountPath: '/usr/src/app/serve.json'
               subPath: serve.json
+          {{ end }}
       volumes:
       {{ if .Values.enableInternalEncryption }}
         - name: frontend-cert
           secret:
             secretName: frontend-cert
       {{ end }}
+      {{ if .Values.enableHSTSHeader }}
         - name: config-map
           configMap:
             name: frontend-config
+      {{ end }}
  
 {{ if .Values.separateIngestAPI }}
 ---

--- a/assemblyline/values.yaml
+++ b/assemblyline/values.yaml
@@ -143,6 +143,13 @@ ingressHost:
 # If left null, a self signed cert will be generated.
 tlsSecretName:
 
+# HSTS management
+# see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+# Set to true to enable HSTS
+enableHSTSHeader: false
+# Max Age value to send in HSTS header when enabled
+HSTSMaxAge: 31536000
+
 # Turn on the directory reader module
 enableVacuum: false
 vacuumVolumes:


### PR DESCRIPTION
Support for AL_HSTS_MAX_AGE environment variable in ui pod.

Add serve.json when enabled to set the HSTS header in the frontend pod.

See PR https://github.com/CybercentreCanada/assemblyline-ui/pull/818 for further details.