### PR TITLE
Datastore-master "create-certs" timing fixes.

### DIFF
--- a/assemblyline/values.yaml
+++ b/assemblyline/values.yaml
@@ -597,7 +597,7 @@ datastore:
             name: elastic-helper-secret
             key: password
       image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
-      command: ['bash', '-c', 'cd /data/; curl --retry 30 --retry-delay 30 -v -k -H "Authorization: Bearer $SECRET_KEY" -O https://elastic-helper:8000/elastic-stack-ca.p12; curl --retry 30 --retry-delay 30 -v -k -H "Authorization: Bearer $SECRET_KEY" -O https://elastic-helper:8000/elastic-certificates.p12; ls -la']
+      command: ['bash', '-c', 'cd /data/ && curl --retry 30 --retry-connrefused --retry-delay 30 -v -k -H "Authorization: Bearer $SECRET_KEY" -O https://elastic-helper:8000/elastic-stack-ca.p12 && curl --retry 30 --retry-connrefused --retry-delay 30 -v -k -H "Authorization: Bearer $SECRET_KEY" -O https://elastic-helper:8000/elastic-certificates.p12 && ls -la']
       volumeMounts:
         - name: elastic-certificates
           mountPath: /data/


### PR DESCRIPTION
- Make curl retry on "connection refused" error - if an attempt to retrieve the Elastic certificates is made between the elastic-helper pod being assigned an IP address and its web server starting, Curl will not presently retry.  This happens occasionally as a function of timing.
- Propagate failures returned to the shell by Curl to Kubernetes by using `&&` instead of `;` -- this should result in the "create-certs" container being restarted, rather than appearing to succeed and leaving the pod in a bad state.

