### PR TITLE
Small typo in values.yaml for the appliance deployment

### DIFF
--- a/appliance/values.yaml
+++ b/appliance/values.yaml
@@ -165,7 +165,7 @@ datastore:
 filestore:
   persistence:
     size: 20Gi
-    StorageClass: microk8s-hostpath
+    storageClass: microk8s-hostpath
   resources:
     requests:
       memory: 512Mi


### PR DESCRIPTION
Fixed typo in `values.yaml`. The filestore storageClass was misspelled. `StorageClass` instead of `storageClass` wich causes an improper deployment.