### PR TITLE
feat: apply coreSecurityContext to AL services missing the field

### DIFF
--- a/assemblyline/templates/elastic-helper-statefulsets.yaml
+++ b/assemblyline/templates/elastic-helper-statefulsets.yaml
@@ -36,6 +36,8 @@ spec:
       - name: elastic-helper
         image: {{ .Values.assemblylineUIImage }}:{{ .Values.release }}
         command: ["python",  "/mount/share_certificate.py"]
+        securityContext:
+          {{ include "assemblyline.coreSecurityContext" . | indent 10 }}
         ports:
         - containerPort: 8000
         env:
@@ -60,6 +62,8 @@ spec:
       - name: create-certs
         image: {{ .Values.datastore.image }}:{{ .Values.datastore.imageTag }}
         command: [ 'bash', '-c', "if [ ! -f /data/elastic-certificates.p12 ]; then mkdir /tmp/certs/ && elasticsearch-certutil ca --out /tmp/certs/elastic-stack-ca.p12 --pass '' && elasticsearch-certutil cert --name security-master --dns security-master --ca /tmp/certs/elastic-stack-ca.p12 --pass '' --ca-pass '' --out /tmp/certs/elastic-certificates.p12 && mv -n /tmp/certs/* /data/; ls -la /data/; fi" ]
+        securityContext:
+          {{ include "assemblyline.coreSecurityContext" . | indent 10 }}
         resources:
           limits:
             cpu: {{ .Values.elasticHelperLimCPU }}

--- a/assemblyline/templates/jobs.yaml
+++ b/assemblyline/templates/jobs.yaml
@@ -23,6 +23,8 @@ spec:
       containers:
       - name: pi
         image: {{ .Values.assemblylineCoreImage }}:{{ .Values.release }}
+        securityContext:
+          {{ include "assemblyline.coreSecurityContext" . | indent 10 }}
         command: ["python",  "/mount/bootstrap.py"]
         env:
           - name: INITIAL_ADMIN_PASSWORD
@@ -99,6 +101,8 @@ spec:
       containers:
       - name: install-alsvc-{{- . }}
         image: {{ $.Values.assemblylineServiceImagePrefix }}{{ . }}:{{ $.Values.assemblylineServiceVersion }}
+        securityContext:
+          {{ include "assemblyline.coreSecurityContext" $ | indent 10 }}
         imagePullPolicy: Always
         env:
           - name: PRIVILEGED
@@ -151,6 +155,8 @@ spec:
       containers:
         - name: pi
           image: {{ .Values.assemblylineCoreImage }}:{{ .Values.release }}
+          securityContext:
+            {{ include "assemblyline.coreSecurityContext" . | indent 12 }}
           command: ["python",  "/mount/create_serviceaccount_token.py"]
           env:
             - name: NAMESPACE

--- a/assemblyline/templates/redis.yaml
+++ b/assemblyline/templates/redis.yaml
@@ -137,8 +137,6 @@ spec:
         image: {{ .Values.redisImage }}
         command: ['redis-server']
         args: ['--appendonly', 'yes', '--maxclients', '100000', '--auto-aof-rewrite-percentage', '200'{{ if ne (.Values.redisPersistentIOThreads | toString) "1" }}, '--io-threads', '{{ .Values.redisPersistentIOThreads }}'{{ end }} {{if .Values.enableInternalEncryption }}, '--tls-port', '6379', '--port', '0', '--tls-cert-file', '/etc/tls/tls.crt', '--tls-key-file', '/etc/tls/tls.key', '--tls-ca-cert-file', '/etc/root-ca.crt', '--tls-auth-clients', 'no' {{ end }}]
-        securityContext:
-          {{ include "assemblyline.coreSecurityContext" . | indent 12 }}
         ports:
         - containerPort: 6379
         readinessProbe:

--- a/assemblyline/templates/redis.yaml
+++ b/assemblyline/templates/redis.yaml
@@ -28,6 +28,8 @@ spec:
       affinity:
         nodeAffinity:
           {{ include "assemblyline.nodeAffinity" . | indent 10 }}
+      securityContext:
+        fsGroup: 1000
       tolerations:
         {{ include "assemblyline.tolerations" . | indent 8 }}
       containers:
@@ -130,6 +132,8 @@ spec:
       affinity:
         nodeAffinity:
           {{ include "assemblyline.nodeAffinity" . | indent 10 }}
+      securityContext:
+        fsGroup: 1000
       tolerations:
         {{ include "assemblyline.tolerations" . | indent 8 }}
       containers:

--- a/assemblyline/templates/redis.yaml
+++ b/assemblyline/templates/redis.yaml
@@ -25,8 +25,6 @@ spec:
     spec:
       priorityClassName: al-infra
       serviceAccountName: {{ .Values.coreServiceAccountName }}
-      securityContext:
-        fsGroup: 1000
       affinity:
         nodeAffinity:
           {{ include "assemblyline.nodeAffinity" . | indent 10 }}
@@ -129,8 +127,6 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
       priorityClassName: al-infra
-      securityContext:
-        fsGroup: 1000
       affinity:
         nodeAffinity:
           {{ include "assemblyline.nodeAffinity" . | indent 10 }}

--- a/assemblyline/templates/redis.yaml
+++ b/assemblyline/templates/redis.yaml
@@ -25,6 +25,8 @@ spec:
     spec:
       priorityClassName: al-infra
       serviceAccountName: {{ .Values.coreServiceAccountName }}
+      securityContext:
+        fsGroup: 1000
       affinity:
         nodeAffinity:
           {{ include "assemblyline.nodeAffinity" . | indent 10 }}
@@ -34,6 +36,8 @@ spec:
         - name: redis
           image: {{ .Values.redisImage }}
           command: ['redis-server']
+          securityContext:
+            {{ include "assemblyline.coreSecurityContext" . | indent 12 }}
           args: ['--appendonly', 'no', '--maxclients', '100000', '--save', ''{{ if ne (.Values.redisVolatileIOThreads | toString) "1" }}, '--io-threads', '{{ .Values.redisVolatileIOThreads }}'{{ end }} {{if .Values.enableInternalEncryption }}, '--tls-port', '6379', '--port', '0', '--tls-cert-file', '/etc/tls/tls.crt', '--tls-key-file', '/etc/tls/tls.key', '--tls-ca-cert-file', '/etc/root-ca.crt', '--tls-auth-clients', 'no' {{ end }}]
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
@@ -125,6 +129,8 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
       priorityClassName: al-infra
+      securityContext:
+        fsGroup: 1000
       affinity:
         nodeAffinity:
           {{ include "assemblyline.nodeAffinity" . | indent 10 }}
@@ -135,6 +141,8 @@ spec:
         image: {{ .Values.redisImage }}
         command: ['redis-server']
         args: ['--appendonly', 'yes', '--maxclients', '100000', '--auto-aof-rewrite-percentage', '200'{{ if ne (.Values.redisPersistentIOThreads | toString) "1" }}, '--io-threads', '{{ .Values.redisPersistentIOThreads }}'{{ end }} {{if .Values.enableInternalEncryption }}, '--tls-port', '6379', '--port', '0', '--tls-cert-file', '/etc/tls/tls.crt', '--tls-key-file', '/etc/tls/tls.key', '--tls-ca-cert-file', '/etc/root-ca.crt', '--tls-auth-clients', 'no' {{ end }}]
+        securityContext:
+          {{ include "assemblyline.coreSecurityContext" . | indent 12 }}
         ports:
         - containerPort: 6379
         readinessProbe:

--- a/assemblyline/templates/scaler-deployment.yaml
+++ b/assemblyline/templates/scaler-deployment.yaml
@@ -40,6 +40,8 @@ spec:
           {{ else }}
           command: ['python', '-m', 'assemblyline_core.scaler.run_scaler']
           {{ end}}
+          securityContext:
+            {{ include "assemblyline.coreSecurityContext" . | indent 12 }}          
           volumeMounts:
           {{ include "assemblyline.coreMounts" . | indent 12 }}
           {{if .Values.enableInternalEncryption }}

--- a/assemblyline/templates/service-server-deployment.yaml
+++ b/assemblyline/templates/service-server-deployment.yaml
@@ -38,6 +38,8 @@ spec:
           {{ if .Values.enableCoreDebugging}}
           command: ["python", "-m", "debugpy", "--listen", "localhost:5678", "-m", "assemblyline_service_server.app"]
           {{ end }}
+          securityContext:
+            {{ include "assemblyline.coreSecurityContext" . | indent 12 }}
           volumeMounts:
           {{ if .Values.enableInternalEncryption }}
             - name: service-server-cert

--- a/assemblyline/templates/ui.yaml
+++ b/assemblyline/templates/ui.yaml
@@ -89,6 +89,8 @@ spec:
             - name: KEYFILE
               value: /etc/assemblyline/ssl/ui/tls.key
           {{ end}}
+          securityContext:
+            {{ include "assemblyline.coreSecurityContext" . | indent 12 }}
           volumeMounts:
           {{ include "assemblyline.coreMounts" . | indent 12 }}
           {{ if .Values.enableInternalEncryption }}
@@ -206,6 +208,8 @@ spec:
             - name: KEYFILE
               value: /etc/assemblyline/ssl/sio/tls.key
           {{ end}}
+          securityContext:
+            {{ include "assemblyline.coreSecurityContext" . | indent 12 }}
           volumeMounts:
           {{ include "assemblyline.coreMounts" . | indent 12 }}
           {{ if .Values.tlsSecretProvider.enabled }} # Loads TLS certs from a secret provider
@@ -327,6 +331,8 @@ spec:
             limits:
               cpu: 1
               memory:  {{ .Values.frontendLimRam}}
+          securityContext:
+            {{ include "assemblyline.coreSecurityContext" . | indent 12 }}
           volumeMounts:
           {{ if .Values.enableInternalEncryption }}
             - name: frontend-cert

--- a/assemblyline/templates/updater-deployment.yaml
+++ b/assemblyline/templates/updater-deployment.yaml
@@ -40,6 +40,8 @@ spec:
           {{ else }}
           command: ['python', '-m', 'assemblyline_core.updater.run_updater']
           {{ end}}
+          securityContext:
+            {{ include "assemblyline.coreSecurityContext" . | indent 12 }}          
           volumeMounts:
           {{ include "assemblyline.coreMounts" . | indent 12 }}
           env:

--- a/assemblyline/values.yaml
+++ b/assemblyline/values.yaml
@@ -521,6 +521,7 @@ configuration:
         host: redis-persistent
         port: 6379
     scaler:
+      enable_pod_security: true
       cluster_pod_list: true
       service_defaults:
         backlog: 10
@@ -663,6 +664,13 @@ datastore:
             key: password
       image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
       command: ['bash', '-c', 'cd /data/ && curl --retry 30 --retry-connrefused --retry-delay 30 -k -H "Authorization: Bearer $SECRET_KEY" -O https://elastic-helper:8000/elastic-stack-ca.p12 && curl --retry 30 --retry-connrefused --retry-delay 30 -k -H "Authorization: Bearer $SECRET_KEY" -O https://elastic-helper:8000/elastic-certificates.p12 && ls -la']
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: elastic-certificates
           mountPath: /data/

--- a/assemblyline/values.yaml
+++ b/assemblyline/values.yaml
@@ -521,7 +521,7 @@ configuration:
         host: redis-persistent
         port: 6379
     scaler:
-      enable_pod_security: true
+      enable_pod_security: false
       cluster_pod_list: true
       service_defaults:
         backlog: 10


### PR DESCRIPTION
Apply `coreSecurityContext` to Assemblyline services missing the field

These changes enable assemblyline to run in a restricted kubernetes namespace with the following `coreSecurityContext`
```yaml
coreSecurityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop: ["ALL"]
  runAsNonRoot: true
  seccompProfile:
    type: RuntimeDefault
  runAsUser: 1000
  runAsGroup: 1000
```

Requires: https://github.com/CybercentreCanada/assemblyline-core/pull/1042